### PR TITLE
Ensure everything compiles individually & sort includes

### DIFF
--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp
@@ -14,6 +14,8 @@
 #ifndef BASIC_RADIX2_DOMAIN_HPP_
 #define BASIC_RADIX2_DOMAIN_HPP_
 
+#include <vector>
+
 #include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libfqfft {

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
@@ -14,6 +14,10 @@
 #ifndef BASIC_RADIX2_DOMAIN_TCC_
 #define BASIC_RADIX2_DOMAIN_TCC_
 
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/common/double.hpp>
+#include <libff/common/utils.hpp>
+
 #include <libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp>
 
 namespace libfqfft {

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp
@@ -15,6 +15,8 @@
 #ifndef BASIC_RADIX2_DOMAIN_AUX_HPP_
 #define BASIC_RADIX2_DOMAIN_AUX_HPP_
 
+#include <vector>
+
 namespace libfqfft {
 
 /**

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.tcc
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.tcc
@@ -15,6 +15,7 @@
 #define BASIC_RADIX2_DOMAIN_AUX_TCC_
 
 #include <algorithm>
+#include <vector>
 
 #ifdef MULTICORE
 #include <omp.h>
@@ -23,6 +24,10 @@
 #include <libff/algebra/fields/field_utils.hpp>
 
 #include <libfqfft/tools/exceptions.hpp>
+
+#ifdef DEBUG
+#include <libff/common/profiling.hpp>
+#endif
 
 namespace libfqfft {
 

--- a/libfqfft/evaluation_domain/evaluation_domain.hpp
+++ b/libfqfft/evaluation_domain/evaluation_domain.hpp
@@ -27,6 +27,7 @@
 #define EVALUATION_DOMAIN_HPP_
 
 #include <memory>
+#include <vector>
 
 namespace libfqfft {
 

--- a/libfqfft/evaluation_domain/evaluation_domain.tcc
+++ b/libfqfft/evaluation_domain/evaluation_domain.tcc
@@ -19,12 +19,11 @@
 #ifndef EVALUATION_DOMAIN_TCC_
 #define EVALUATION_DOMAIN_TCC_
 
+#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
-
+#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
 #include <libfqfft/tools/exceptions.hpp>
 
 namespace libfqfft {

--- a/libfqfft/kronecker_substitution/kronecker_substitution.hpp
+++ b/libfqfft/kronecker_substitution/kronecker_substitution.hpp
@@ -12,6 +12,8 @@
 #ifndef KRONECKER_SUBSTITUTION_HPP_
 #define KRONECKER_SUBSTITUTION_HPP_
 
+#include <vector>
+
 namespace libfqfft {
 
 /**

--- a/libfqfft/kronecker_substitution/kronecker_substitution.tcc
+++ b/libfqfft/kronecker_substitution/kronecker_substitution.tcc
@@ -15,9 +15,10 @@
 #define KRONECKER_SUBSTITUTION_TCC_
 
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
-#define GMP_LIMB_BITS 64
+#include <gmp.h>
+#include <libff/common/utils.hpp>
 
 namespace libfqfft {
 
@@ -44,7 +45,7 @@ void kronecker_substitution(std::vector<FieldT> &v3, const std::vector<FieldT> &
     /* Output polynomial */
     v3.resize(n3, FieldT::zero());
 
-    /* 
+    /*
      * Allocate all MP_LIMB_T space once and store the reference pointer M1
      * to free memory afterwards. P1, P2, and P3 will remain fixed pointers
      * to the start of their respective polynomials as reference.
@@ -72,7 +73,7 @@ void kronecker_substitution(std::vector<FieldT> &v3, const std::vector<FieldT> &
         val = v1[i].as_ulong();
         limb += (val << limb_b);
 
-        /* 
+        /*
          * If the next iteration of LIMB_B is >= to the GMP_LIMB_BITS, then
          * write it out to MP_LIMB_T* and reset LIMB. If VAL has remaining
          * bits due to GMP_LIMB_BITS boundary, set it in LIMB and proceed.
@@ -99,7 +100,7 @@ void kronecker_substitution(std::vector<FieldT> &v3, const std::vector<FieldT> &
             val = v2[i].as_ulong();
             limb += (val << limb_b);
 
-            /* 
+            /*
              * If the next iteration of LIMB_B is >= to the GMP_LIMB_BITS, then
              * write it out to MP_LIMB_T* and reset LIMB. If VAL has remaining
              * bits due to GMP_LIMB_BITS boundary, set it in LIMB and proceed.
@@ -130,7 +131,7 @@ void kronecker_substitution(std::vector<FieldT> &v3, const std::vector<FieldT> &
         limb_b = 0;
         for (size_t i = 0; i < n3; i++)
         {
-            /* 
+            /*
              * If the coefficient's bit length is contained in LIMB, then
              * write the masked value out to vector V3 and decrement LIMB
              * by B bits.
@@ -142,7 +143,7 @@ void kronecker_substitution(std::vector<FieldT> &v3, const std::vector<FieldT> &
                 delta = b;
                 delta_b = limb_b - delta;
             }
-            /* 
+            /*
              * If the remaining coefficient is across two LIMBs, then write
              * to vector V3 the current limb's value and add upper bits from
              * the second part. Lastly, decrement LIMB by the coefficient's

--- a/libfqfft/polynomial_arithmetic/basic_operations.hpp
+++ b/libfqfft/polynomial_arithmetic/basic_operations.hpp
@@ -3,7 +3,7 @@
  *****************************************************************************
 
  Declaration of interfaces for basic polynomial operation routines.
- 
+
  *****************************************************************************
  * @author     This file is part of libfqfft, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
@@ -12,6 +12,8 @@
 
 #ifndef BASIC_OPERATIONS_HPP_
 #define BASIC_OPERATIONS_HPP_
+
+#include <vector>
 
 namespace libfqfft {
 

--- a/libfqfft/polynomial_arithmetic/basis_change.hpp
+++ b/libfqfft/polynomial_arithmetic/basis_change.hpp
@@ -2,7 +2,7 @@
  *****************************************************************************
 
  Declaration of interfaces for basis change routines.
- 
+
  *****************************************************************************
  * @author     This file is part of libfqfft, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
@@ -11,6 +11,8 @@
 
 #ifndef BASIS_CHANGE_HPP_
 #define BASIS_CHANGE_HPP_
+
+#include <vector>
 
 namespace libfqfft {
 

--- a/libfqfft/polynomial_arithmetic/basis_change.tcc
+++ b/libfqfft/polynomial_arithmetic/basis_change.tcc
@@ -15,9 +15,10 @@
 #define BASIS_CHANGE_TCC_
 
 #include <algorithm>
+
+#include <libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp>
 #include <libfqfft/polynomial_arithmetic/basic_operations.hpp>
 #include <libfqfft/polynomial_arithmetic/xgcd.hpp>
-#include <libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp>
 
 namespace libfqfft {
 

--- a/libfqfft/polynomial_arithmetic/naive_evaluate.hpp
+++ b/libfqfft/polynomial_arithmetic/naive_evaluate.hpp
@@ -2,7 +2,7 @@
  *****************************************************************************
 
  Declaration of interfaces for naive evaluation routines.
- 
+
  *****************************************************************************
  * @author     This file is part of libfqfft, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
@@ -11,6 +11,10 @@
 
 #ifndef NAIVE_EVALUATE_HPP_
 #define NAIVE_EVALUATE_HPP_
+
+#include <vector>
+
+#include <libfqfft/tools/exceptions.hpp>
 
 namespace libfqfft {
 

--- a/libfqfft/polynomial_arithmetic/xgcd.hpp
+++ b/libfqfft/polynomial_arithmetic/xgcd.hpp
@@ -2,7 +2,7 @@
  *****************************************************************************
 
  Declaration of interfaces for extended GCD routines.
- 
+
  *****************************************************************************
  * @author     This file is part of libfqfft, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
@@ -11,6 +11,8 @@
 
 #ifndef XGCD_HPP_
 #define XGCD_HPP_
+
+#include <vector>
 
 namespace libfqfft {
 

--- a/libfqfft/polynomial_arithmetic/xgcd.tcc
+++ b/libfqfft/polynomial_arithmetic/xgcd.tcc
@@ -15,8 +15,9 @@
 #define XGCD_TCC_
 
 #include <algorithm>
-#include <libfqfft/polynomial_arithmetic/basic_operations.hpp>
+
 #include <libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp>
+#include <libfqfft/polynomial_arithmetic/basic_operations.hpp>
 
 namespace libfqfft {
 

--- a/libfqfft/profiling/profile/profile.cpp
+++ b/libfqfft/profiling/profile/profile.cpp
@@ -9,28 +9,27 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
+#ifndef PROFILE_OP_COUNTS
+#error PROFILE_OP_COUNTS must be defined to build this profiler.
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <ctime>
-#include <iostream>
 #include <fstream>
-#include <omp.h>
+#include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <vector>
 #include <sys/resource.h>
 #include <unistd.h>
-#include <vector>
 
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/common/double.hpp>
+#include <omp.h>
 
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp> // this also includes all children of evaluation_domain
 
 using namespace libfqfft;
 

--- a/libfqfft/profiling/profiling_menu.cpp
+++ b/libfqfft/profiling/profiling_menu.cpp
@@ -11,17 +11,18 @@
 
 #include <cmath>
 #include <ctime>
-#include <dirent.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
+#include <vector>
+
+#include <dirent.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/resource.h>
 #include <unistd.h>
-#include <vector>
 
 /* Level 2: Profile */
 void profile()

--- a/libfqfft/tests/evaluation_domain_test.cpp
+++ b/libfqfft/tests/evaluation_domain_test.cpp
@@ -5,18 +5,13 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <gtest/gtest.h>
-#include <stdint.h>
 #include <vector>
 
+#include <gtest/gtest.h>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <stdint.h>
 
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
-#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp> // this also includes all children of evaluation_domain
 #include <libfqfft/polynomial_arithmetic/naive_evaluate.hpp>
 #include <libfqfft/tools/exceptions.hpp>
 
@@ -78,7 +73,7 @@ namespace libfqfft {
       }
     }
   }
-  
+
   TYPED_TEST(EvaluationDomainTest, InverseFFTofFFT) {
 
     const size_t m = 4;
@@ -111,7 +106,7 @@ namespace libfqfft {
       catch(const InvalidSizeException &e)
       {
         printf("%s - skipping\n", e.what());
-      } 
+      }
     }
   }
 
@@ -161,7 +156,7 @@ namespace libfqfft {
     std::shared_ptr<evaluation_domain<TypeParam> > domain;
     for (int key = 0; key < 5; key++)
     {
-        
+
       try
       {
         if (key == 0) domain.reset(new basic_radix2_domain<TypeParam>(m));
@@ -198,7 +193,7 @@ namespace libfqfft {
   }
 
   TYPED_TEST(EvaluationDomainTest, ComputeZ) {
-    
+
     const size_t m = 8;
     TypeParam t = TypeParam(10);
 

--- a/libfqfft/tests/kronecker_substitution_test.cpp
+++ b/libfqfft/tests/kronecker_substitution_test.cpp
@@ -5,9 +5,10 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
  
+#include <vector>
+
 #include <gtest/gtest.h>
 #include <stdint.h>
-#include <vector>
 
 #include <libfqfft/polynomial_arithmetic/basic_operations.hpp>
 

--- a/libfqfft/tests/polynomial_arithmetic_test.cpp
+++ b/libfqfft/tests/polynomial_arithmetic_test.cpp
@@ -5,9 +5,10 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
+#include <vector>
+
 #include <gtest/gtest.h>
 #include <stdint.h>
-#include <vector>
 
 #include <libfqfft/polynomial_arithmetic/basic_operations.hpp>
 #include <libfqfft/polynomial_arithmetic/xgcd.hpp>


### PR DESCRIPTION
Just like in [libff pull request 9](https://github.com/scipr-lab/libff/pull/9), I have made *almost* every file in libfqfft compile individually by adding all missing includes, and also sorted all includes.

Additionally, I added a helpful compilation error message in case someone tries to compile `libfqfft/profiling/profile/profile.cpp` without `-DPROFILE_OP_COUNTS`.

Now for the *almost* in that first paragraph. There is a set of files, all in `libfqfft/evaluation_domain`, that still cannot be compiled individually, and this cannot be fixed easily because they have circular dependencies (files in `domains/*` depend on `evaluation_domain.hpp`, and vice-versa).

I see two solutions to this:

- add an explicit compiler error message to each file in `domains/*` saying that it cannot be compiled or included individually and must only be used by including `evaluation_domain.hpp`

- move `get_evaluation_domain()` from `evaluation_domain.hpp` to a separate file, like `get_evaluation_domain.hpp`, eliminating the circular dependency

Personally, I support the second solution, because I don't see why a user should be unable to include a specific evalution domain if they want to. However, this would be a breaking change for all users of libfqfft (so, basically, libsnark), although it would also be really easy to fix (by adding/replacing just one include).

I invite everybody else to discuss this issue in the comments for this pull request. If there is support for either of the solutions, I will implement it and submit another PR to libfqfft (or just add more commits to this one), and also implement the necessary changes in libsnark if there are any.