### PR TITLE
Refactor get_evaluation_domain into a separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ else()
   )
 endif()
 
+include_directories(.)
+
 # GMP
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARIES NAMES gmp libgmp)
@@ -101,6 +103,5 @@ add_custom_target(
   COMMAND polynomial_multiplication
 )
 
-include_directories(.)
 add_subdirectory(libfqfft)
 add_subdirectory(tutorials)

--- a/libfqfft/evaluation_domain/evaluation_domain.hpp
+++ b/libfqfft/evaluation_domain/evaluation_domain.hpp
@@ -26,7 +26,6 @@
 #ifndef EVALUATION_DOMAIN_HPP_
 #define EVALUATION_DOMAIN_HPP_
 
-#include <memory>
 #include <vector>
 
 namespace libfqfft {
@@ -99,15 +98,6 @@ public:
     virtual void divide_by_Z_on_coset(std::vector<FieldT> &P) = 0;
 };
 
-/**
- * Return an evaluation domain object in which the domain S has size |S| >= min_size.
- * The function chooses from different supported domains, depending on min_size.
- */
-template<typename FieldT>
-std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t min_size);
-
 } // libfqfft
-
-#include <libfqfft/evaluation_domain/evaluation_domain.tcc>
 
 #endif // EVALUATION_DOMAIN_HPP_

--- a/libfqfft/evaluation_domain/get_evaluation_domain.hpp
+++ b/libfqfft/evaluation_domain/get_evaluation_domain.hpp
@@ -1,0 +1,32 @@
+/** @file
+ *****************************************************************************
+
+ A convenience method for choosing an evaluation domain
+
+ Returns an evaluation domain object in which the domain S has size
+ |S| >= min_size.
+ The function chooses from different supported domains, depending on min_size.
+
+ *****************************************************************************
+ * @author     This file is part of libfqfft, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef GET_EVALUATION_DOMAIN_HPP_
+#define GET_EVALUATION_DOMAIN_HPP_
+
+#include <memory>
+
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
+
+namespace libfqfft {
+
+template<typename FieldT>
+std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t min_size);
+
+} // libfqfft
+
+#include <libfqfft/evaluation_domain/get_evaluation_domain.tcc>
+
+#endif // GET_EVALUATION_DOMAIN_HPP_

--- a/libfqfft/evaluation_domain/get_evaluation_domain.tcc
+++ b/libfqfft/evaluation_domain/get_evaluation_domain.tcc
@@ -16,14 +16,15 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#ifndef EVALUATION_DOMAIN_TCC_
-#define EVALUATION_DOMAIN_TCC_
+#ifndef GET_EVALUATION_DOMAIN_TCC_
+#define GET_EVALUATION_DOMAIN_TCC_
 
 #include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
 #include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 #include <libfqfft/tools/exceptions.hpp>
 
 namespace libfqfft {
@@ -52,4 +53,4 @@ std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t m
 
 } // libfqfft
 
-#endif // EVALUATION_DOMAIN_TCC_
+#endif // GET_EVALUATION_DOMAIN_TCC_

--- a/libfqfft/profiling/profile/profile.cpp
+++ b/libfqfft/profiling/profile/profile.cpp
@@ -29,7 +29,11 @@
 #include <libff/common/double.hpp>
 #include <omp.h>
 
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp> // this also includes all children of evaluation_domain
+#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
 
 using namespace libfqfft;
 

--- a/libfqfft/tests/evaluation_domain_test.cpp
+++ b/libfqfft/tests/evaluation_domain_test.cpp
@@ -5,13 +5,18 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <stdint.h>
 
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp> // this also includes all children of evaluation_domain
+#include <libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp>
+#include <libfqfft/evaluation_domain/domains/step_radix2_domain.hpp>
 #include <libfqfft/polynomial_arithmetic/naive_evaluate.hpp>
 #include <libfqfft/tools/exceptions.hpp>
 


### PR DESCRIPTION
As discussed in #4.

After this change, all .hpp and .cpp files in libfqfft can be compiled individually without errors.

While implementing this, I also fixed a slight issue with the build system which could cause the wrong headers to be used at build time (see the relevant commit for more details).

libsnark pull request coming in a moment.