### PR TITLE
Fix compiler warnings & avoid floating point arithmetic

### DIFF
--- a/libfqfft/polynomial_arithmetic/basis_change.tcc
+++ b/libfqfft/polynomial_arithmetic/basis_change.tcc
@@ -34,8 +34,8 @@ void compute_subproduct_tree(const size_t &m, std::vector< std::vector < std::ve
      */
 
     /* Precompute the first row. */
-    T[0] = std::vector< std::vector<FieldT> >(pow(2, m));
-    for (int j = 0; j < pow(2, m); j++)
+    T[0] = std::vector< std::vector<FieldT> >(1u << m);
+    for (size_t j = 0; j < (1u << m); j++)
     {
         T[0][j] = std::vector<FieldT>(2, FieldT::one());
         T[0][j][0] = FieldT(-j);
@@ -47,8 +47,8 @@ void compute_subproduct_tree(const size_t &m, std::vector< std::vector < std::ve
     size_t index = 0;
     for (size_t i = 1; i <= m; i++)
     {
-        T[i] = std::vector<std::vector<FieldT> >(pow(2, m-i));
-        for (int j = 0; j < pow(2, m-i); j++)
+        T[i] = std::vector<std::vector<FieldT> >(1u << (m-i));
+        for (size_t j = 0; j < (1u << (m-i)); j++)
         {
             a = T[i-1][index];
             index++;
@@ -88,22 +88,32 @@ void monomial_to_newton_basis(std::vector<FieldT> &a, const std::vector<std::vec
 
     size_t row_length;
     size_t c_vec;
-    for (int i = m - 1; i >= 0; i--)
+    /* NB: unsigned reverse iteration: cannot do i >= 0, but can do i < m
+       because unsigned integers are guaranteed to wrap around */
+    for (size_t i = m - 1; i < m; i--)
     {
         row_length = T[i].size() - 1;
-        c_vec = pow(2, i);
+        c_vec = 1u << i;
 
-        for (int j = pow(2, m - i - 1) - 1; j >= 0; j--)
+        /* NB: unsigned reverse iteration */
+        for (size_t j = (1u << (m - i - 1)) - 1;
+             j < (1u << (m - i - 1));
+             j--)
         {
-            c[2*j+1] = _polynomial_multiplication_transpose(pow(2, i) - 1, T[i][row_length - 2*j], c[j]);
+            c[2*j+1] = _polynomial_multiplication_transpose(
+                (1u << i) - 1, T[i][row_length - 2*j], c[j]);
             c[2*j] = c[j];
             c[2*j].resize(c_vec);
         }
     }
 
     /* Store Computed Newton Basis Coefficients */
-    int j = 0;
-    for (int i = c.size() - 1; i >= 0; i--) a[j++] = c[i][0];
+    size_t j = 0;
+    /* NB: unsigned reverse iteration */
+    for (size_t i = c.size() - 1; i < c.size(); i--)
+    {
+        a[j++] = c[i][0];
+    }
 }
 
 template<typename FieldT>
@@ -122,7 +132,7 @@ void newton_to_monomial_basis(std::vector<FieldT> &a, const std::vector<std::vec
     std::vector<FieldT> temp(1, FieldT::zero());
     for (size_t i = 0; i < m; i++)
     {
-        for (int j = 0; j < pow(2, m - i - 1); j++)
+        for (size_t j = 0; j < (1u << (m - i - 1)); j++)
         {
             _polynomial_multiplication(temp, T[i][2*j], f[2*j + 1]);
             _polynomial_addition(f[j], f[2*j], temp);

--- a/libfqfft/polynomial_arithmetic/basis_change.tcc
+++ b/libfqfft/polynomial_arithmetic/basis_change.tcc
@@ -40,19 +40,19 @@ void compute_subproduct_tree(const size_t &m, std::vector< std::vector < std::ve
         T[0][j] = std::vector<FieldT>(2, FieldT::one());
         T[0][j][0] = FieldT(-j);
     }
-    
+
     std::vector<FieldT> a;
     std::vector<FieldT> b;
 
     size_t index = 0;
-    for (int i = 1; i <= m; i++)
+    for (size_t i = 1; i <= m; i++)
     {
         T[i] = std::vector<std::vector<FieldT> >(pow(2, m-i));
         for (int j = 0; j < pow(2, m-i); j++)
         {
             a = T[i-1][index];
             index++;
-            
+
             b = T[i-1][index];
             index++;
 
@@ -65,8 +65,8 @@ void compute_subproduct_tree(const size_t &m, std::vector< std::vector < std::ve
 template<typename FieldT>
 void monomial_to_newton_basis(std::vector<FieldT> &a, const std::vector<std::vector<std::vector<FieldT> > > &T, const size_t &n)
 {
-    int m = log2(n);
-    if (T.size() != m + 1) throw DomainSizeException("expected T.size() == m + 1");
+    size_t m = log2(n);
+    if (T.size() != m + 1u) throw DomainSizeException("expected T.size() == m + 1");
 
     /* MonomialToNewton */
     std::vector<FieldT> I(T[m][0]);
@@ -109,18 +109,18 @@ void monomial_to_newton_basis(std::vector<FieldT> &a, const std::vector<std::vec
 template<typename FieldT>
 void newton_to_monomial_basis(std::vector<FieldT> &a, const std::vector<std::vector<std::vector<FieldT> > > &T, const size_t &n)
 {
-    int m = log2(n);
-    if (T.size() != m + 1) throw DomainSizeException("expected T.size() == m + 1");
+    size_t m = log2(n);
+    if (T.size() != m + 1u) throw DomainSizeException("expected T.size() == m + 1");
 
     std::vector < std::vector <FieldT> > f(n);
-    for (int i = 0; i < n; i++)
+    for (size_t i = 0; i < n; i++)
     {
         f[i] = std::vector<FieldT>(1, a[i]);
     }
-    
+
     /* NewtonToMonomial */
     std::vector<FieldT> temp(1, FieldT::zero());
-    for (int i = 0; i < m; i++)
+    for (size_t i = 0; i < m; i++)
     {
         for (int j = 0; j < pow(2, m - i - 1); j++)
         {

--- a/libfqfft/polynomial_arithmetic/naive_evaluate.tcc
+++ b/libfqfft/polynomial_arithmetic/naive_evaluate.tcc
@@ -4,7 +4,7 @@
  Implementation of interfaces for naive evaluation routines.
 
  See naive_evaluate.hpp .
- 
+
  *****************************************************************************
  * @author     This file is part of libfqfft, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
@@ -25,7 +25,9 @@ FieldT evaluate_polynomial(const size_t &m, const std::vector<FieldT> &coeff, co
 
     FieldT result = FieldT::zero();
 
-    for (int i = m - 1; i >= 0; i--)
+    /* NB: unsigned reverse iteration: cannot do i >= 0, but can do i < m
+       because unsigned integers are guaranteed to wrap around */
+    for (size_t i = m - 1; i < m; i--)
     {
         result = (result * t) + coeff[i];
     }

--- a/libfqfft/profiling/profile/profile.cpp
+++ b/libfqfft/profiling/profile/profile.cpp
@@ -63,8 +63,8 @@ void profile(const std::string domain_sizes,
              const int key)
 {
   /* Determine domain sizes and precompute domain vectors */
-  int n;
-  std::vector<int> dom_sizes;
+  size_t n;
+  std::vector<size_t> dom_sizes;
   std::stringstream domain_stream(domain_sizes);
   while (domain_stream >> n) dom_sizes.push_back(n);
 
@@ -102,7 +102,7 @@ void profile(const std::string domain_sizes,
   printf("\n%s-%d\n", type[key].c_str(), num_threads);
 
   /* Assess on varying domain sizes */
-  for (int s = 0; s < domain.size(); s++) {
+  for (size_t s = 0; s < domain.size(); s++) {
     /* Initialization */
     std::vector<FieldT> a(domain[s]);
     const size_t n = a.size();

--- a/libfqfft/profiling/profiling_menu.cpp
+++ b/libfqfft/profiling/profiling_menu.cpp
@@ -148,7 +148,7 @@ void profile()
             if (key < 3 && domain_type == 3) continue;
             if (system(("./profiler "
                         + std::to_string(key) + " "
-                        + std::to_string(pow(2, threads)) + " "
+                        + std::to_string(1u << threads) + " "
                         + datetime + " "
                         + "\"" + profile_type + "\" "
                         + "\"" + domains[domain_choice] + "\"").c_str()))


### PR DESCRIPTION
A couple of files in libfqfft used `int` where `size_t` is more appropriate, resulting in "signed/unsigned comparison" warnings when compiling libfqfft or libsnark.

Additionally, sometimes `pow(2, x)` was used to calculate an integer power of two, which is actually a function that operates on floating point numbers. `(1 << x)` is a faster and safer way to do that.

This pull request fixes both of these issues. Compiling libfqfft with gcc with `-Wall -Wno-unknown-pragmas -Werror` now succeeds and reports no warnings (`-Wno-unknown-pragmas` is required when compiling without openmp).