### PR TITLE
Do not use exceptions control flow

### DIFF
--- a/libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.hpp
@@ -28,6 +28,8 @@ namespace libfqfft {
     FieldT arithmetic_generator;
     void do_precomputation();
 
+    static bool valid_for_size(const size_t m);
+
     arithmetic_sequence_domain(const size_t m);
 
     void FFT(std::vector<FieldT> &a);

--- a/libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/arithmetic_sequence_domain.tcc
@@ -24,6 +24,18 @@
 namespace libfqfft {
 
 template<typename FieldT>
+bool arithmetic_sequence_domain<FieldT>::valid_for_size(const size_t m)
+{
+  if (m <=1)
+      return false;
+
+  if (FieldT::arithmetic_generator() == FieldT::zero())
+      return false;
+
+  return true;
+}
+
+template<typename FieldT>
 arithmetic_sequence_domain<FieldT>::arithmetic_sequence_domain(const size_t m) : evaluation_domain<FieldT>(m)
 {
   if (m <= 1) throw InvalidSizeException("arithmetic(): expected m > 1");

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain.hpp
@@ -26,6 +26,8 @@ public:
 
     FieldT omega;
 
+    static bool valid_for_size(const size_t m);
+
     basic_radix2_domain(const size_t m);
 
     void FFT(std::vector<FieldT> &a);

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
@@ -23,6 +23,27 @@
 namespace libfqfft {
 
 template<typename FieldT>
+bool basic_radix2_domain<FieldT>::valid_for_size(const size_t m)
+{
+    if ( m <= 1 )
+        return false;
+
+    // Will `get_root_of_unity` throw?
+    if (!std::is_same<FieldT, libff::Double>::value)
+    {
+        const size_t logm = libff::log2(m);
+
+        if (logm > FieldT::s)
+            return false;
+
+        if (m != 1u << logm)
+            return false;
+    }
+
+    return true;
+}
+
+template<typename FieldT>
 basic_radix2_domain<FieldT>::basic_radix2_domain(const size_t m) : evaluation_domain<FieldT>(m)
 {
     if (m <= 1) throw InvalidSizeException("basic_radix2(): expected m > 1");

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc
@@ -35,10 +35,10 @@ bool basic_radix2_domain<FieldT>::valid_for_size(const size_t m)
 
         if (logm > FieldT::s)
             return false;
-
-        if (m != 1u << logm)
-            return false;
     }
+
+    if( get_root_of_unity_will_throw<FieldT>(m) )
+        return false;
 
     return true;
 }

--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.tcc
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.tcc
@@ -61,7 +61,7 @@ void _basic_serial_radix2_FFT(std::vector<FieldT> &a, const FieldT &omega)
         // w_m is 2^s-th root of unity now
         const FieldT w_m = omega^(n/(2*m));
 
-        asm volatile  ("/* pre-inner */");
+        //asm volatile  ("/* pre-inner */");
         for (size_t k = 0; k < n; k += 2*m)
         {
             FieldT w = FieldT::one();
@@ -73,7 +73,7 @@ void _basic_serial_radix2_FFT(std::vector<FieldT> &a, const FieldT &omega)
                 w *= w_m;
             }
         }
-        asm volatile ("/* post-inner */");
+        //asm volatile ("/* post-inner */");
         m *= 2;
     }
 }

--- a/libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/extended_radix2_domain.hpp
@@ -27,6 +27,8 @@ public:
     FieldT omega;
     FieldT shift;
 
+    static bool valid_for_size(const size_t m);
+
     extended_radix2_domain(const size_t m);
 
     void FFT(std::vector<FieldT> &a);

--- a/libfqfft/evaluation_domain/domains/extended_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/extended_radix2_domain.tcc
@@ -18,6 +18,32 @@
 namespace libfqfft {
 
 template<typename FieldT>
+bool extended_radix2_domain<FieldT>::valid_for_size(const size_t m)
+{
+    if ( m <= 1 )
+        return false;
+
+    // Will `get_root_of_unity` throw?
+    if (!std::is_same<FieldT, libff::Double>::value)
+    {
+        const size_t logm = libff::log2(m);
+
+        if (logm != (FieldT::s + 1))
+            return false;
+
+        size_t small_m = m / 2;
+
+        if (small_m > FieldT::s)
+            return false;
+
+        if (m != (1u << small_m))
+            return false;
+    }
+
+    return true;
+}
+
+template<typename FieldT>
 extended_radix2_domain<FieldT>::extended_radix2_domain(const size_t m) : evaluation_domain<FieldT>(m)
 {
     if (m <= 1) throw InvalidSizeException("extended_radix2(): expected m > 1");

--- a/libfqfft/evaluation_domain/domains/extended_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/extended_radix2_domain.tcc
@@ -30,15 +30,12 @@ bool extended_radix2_domain<FieldT>::valid_for_size(const size_t m)
 
         if (logm != (FieldT::s + 1))
             return false;
-
-        size_t small_m = m / 2;
-
-        if (small_m > FieldT::s)
-            return false;
-
-        if (m != (1u << small_m))
-            return false;
     }
+
+    size_t small_m = m / 2;
+
+    if( get_root_of_unity_will_throw<FieldT>(small_m) )
+        return false;
 
     return true;
 }

--- a/libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/geometric_sequence_domain.hpp
@@ -27,6 +27,8 @@ namespace libfqfft {
     std::vector<FieldT> geometric_triangular_sequence;
     void do_precomputation();
 
+    static bool valid_for_size(const size_t m);
+
     geometric_sequence_domain(const size_t m);
 
     void FFT(std::vector<FieldT> &a);

--- a/libfqfft/evaluation_domain/domains/geometric_sequence_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/geometric_sequence_domain.tcc
@@ -24,6 +24,18 @@
 namespace libfqfft {
 
 template<typename FieldT>
+bool geometric_sequence_domain<FieldT>::valid_for_size(const size_t m)
+{
+    if ( m <= 1 )
+        return false;
+
+    if (FieldT::geometric_generator() == FieldT::zero())
+        return false;
+
+    return true;
+}
+
+template<typename FieldT>
 geometric_sequence_domain<FieldT>::geometric_sequence_domain(const size_t m) : evaluation_domain<FieldT>(m)
 {
   if (m <= 1) throw InvalidSizeException("geometric(): expected m > 1");

--- a/libfqfft/evaluation_domain/domains/step_radix2_domain.hpp
+++ b/libfqfft/evaluation_domain/domains/step_radix2_domain.hpp
@@ -29,6 +29,8 @@ public:
     FieldT big_omega;
     FieldT small_omega;
 
+    static bool valid_for_size(const size_t m);
+
     step_radix2_domain(const size_t m);
 
     void FFT(std::vector<FieldT> &a);

--- a/libfqfft/evaluation_domain/domains/step_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/step_radix2_domain.tcc
@@ -18,6 +18,33 @@
 namespace libfqfft {
 
 template<typename FieldT>
+bool step_radix2_domain<FieldT>::valid_for_size(const size_t m)
+{
+    if ( m <= 1 )
+        return false;
+
+    const size_t big_m = 1ul<<(libff::log2(m)-1);
+    const size_t small_m = m - big_m;
+
+    if (small_m != 1ul<<libff::log2(small_m))
+        return false;
+
+    // Will `get_root_of_unity` throw?
+    if (!std::is_same<FieldT, libff::Double>::value)
+    {
+        const size_t logm = libff::log2(m);
+
+        if (m != (1u << logm))
+            return false;
+
+        if (logm > FieldT::s)
+            return false;
+    }
+
+    return true;
+}
+
+template<typename FieldT>
 step_radix2_domain<FieldT>::step_radix2_domain(const size_t m) : evaluation_domain<FieldT>(m)
 {
     if (m <= 1) throw InvalidSizeException("step_radix2(): expected m > 1");

--- a/libfqfft/evaluation_domain/domains/step_radix2_domain.tcc
+++ b/libfqfft/evaluation_domain/domains/step_radix2_domain.tcc
@@ -29,17 +29,13 @@ bool step_radix2_domain<FieldT>::valid_for_size(const size_t m)
     if (small_m != 1ul<<libff::log2(small_m))
         return false;
 
-    // Will `get_root_of_unity` throw?
-    if (!std::is_same<FieldT, libff::Double>::value)
-    {
-        const size_t logm = libff::log2(m);
+    // omega
+    if( get_root_of_unity_will_throw<FieldT>(1ul<<libff::log2(m)) )
+        return false;
 
-        if (m != (1u << logm))
-            return false;
-
-        if (logm > FieldT::s)
-            return false;
-    }
+    // small_omega
+    if( get_root_of_unity_will_throw<FieldT>(1ul<<libff::log2(small_m)) )
+        return false;
 
     return true;
 }

--- a/libfqfft/evaluation_domain/evaluation_domain.hpp
+++ b/libfqfft/evaluation_domain/evaluation_domain.hpp
@@ -27,8 +27,33 @@
 #define EVALUATION_DOMAIN_HPP_
 
 #include <vector>
+#include <libff/common/double.hpp>
 
 namespace libfqfft {
+
+template<typename FieldT>
+typename std::enable_if<std::is_same<FieldT, libff::Double>::value, bool>::type
+get_root_of_unity_will_throw(const size_t n)
+{
+    return false;
+}
+
+
+template<typename FieldT>
+typename std::enable_if<!std::is_same<FieldT, libff::Double>::value, bool>::type
+get_root_of_unity_will_throw(const size_t n)
+{
+    const size_t logn = libff::log2(n);
+
+    if (n != (1u << logn))
+        return true;
+
+    if (logn > FieldT::s)
+        return true;
+
+    return false;
+}
+
 
 /**
  * An evaluation domain.

--- a/libfqfft/evaluation_domain/get_evaluation_domain.tcc
+++ b/libfqfft/evaluation_domain/get_evaluation_domain.tcc
@@ -38,6 +38,35 @@ std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t m
     const size_t small = min_size - big;
     const size_t rounded_small = (1ul<<libff::log2(small));
 
+    if ( basic_radix2_domain<FieldT>::valid_for_size(min_size) ) {
+        result.reset(new basic_radix2_domain<FieldT>(min_size));        
+    }
+    else if ( extended_radix2_domain<FieldT>::valid_for_size(min_size) ) {
+        result.reset(new extended_radix2_domain<FieldT>(min_size));
+    }
+    else if ( step_radix2_domain<FieldT>::valid_for_size(min_size) ) {
+        result.reset(new step_radix2_domain<FieldT>(min_size));
+    }
+    else if ( basic_radix2_domain<FieldT>::valid_for_size(big + rounded_small) ) {
+        result.reset(new basic_radix2_domain<FieldT>(big + rounded_small));
+    }
+    else if ( extended_radix2_domain<FieldT>::valid_for_size(big + rounded_small) ) {
+        result.reset(new extended_radix2_domain<FieldT>(big + rounded_small));        
+    }
+    else if ( step_radix2_domain<FieldT>::valid_for_size(big + rounded_small) ) {
+        result.reset(new step_radix2_domain<FieldT>(big + rounded_small));
+    }
+    else if ( geometric_sequence_domain<FieldT>::valid_for_size(min_size) ) {
+        result.reset(new geometric_sequence_domain<FieldT>(min_size));
+    }
+    else if ( arithmetic_sequence_domain<FieldT>::valid_for_size(min_size) ) {
+        result.reset(new arithmetic_sequence_domain<FieldT>(min_size));
+    }
+    else {
+        throw DomainSizeException("get_evaluation_domain: no matching domain");
+    }
+
+    /*
     try { result.reset(new basic_radix2_domain<FieldT>(min_size)); }
     catch(...) { try { result.reset(new extended_radix2_domain<FieldT>(min_size)); }
     catch(...) { try { result.reset(new step_radix2_domain<FieldT>(min_size)); }
@@ -47,6 +76,7 @@ std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t m
     catch(...) { try { result.reset(new geometric_sequence_domain<FieldT>(min_size)); }
     catch(...) { try { result.reset(new arithmetic_sequence_domain<FieldT>(min_size)); }
     catch(...) { throw DomainSizeException("get_evaluation_domain: no matching domain"); }}}}}}}}
+    */
 
     return result;
 }

--- a/libfqfft/evaluation_domain/get_evaluation_domain.tcc
+++ b/libfqfft/evaluation_domain/get_evaluation_domain.tcc
@@ -66,18 +66,6 @@ std::shared_ptr<evaluation_domain<FieldT> > get_evaluation_domain(const size_t m
         throw DomainSizeException("get_evaluation_domain: no matching domain");
     }
 
-    /*
-    try { result.reset(new basic_radix2_domain<FieldT>(min_size)); }
-    catch(...) { try { result.reset(new extended_radix2_domain<FieldT>(min_size)); }
-    catch(...) { try { result.reset(new step_radix2_domain<FieldT>(min_size)); }
-    catch(...) { try { result.reset(new basic_radix2_domain<FieldT>(big + rounded_small)); }
-    catch(...) { try { result.reset(new extended_radix2_domain<FieldT>(big + rounded_small)); }
-    catch(...) { try { result.reset(new step_radix2_domain<FieldT>(big + rounded_small)); }
-    catch(...) { try { result.reset(new geometric_sequence_domain<FieldT>(min_size)); }
-    catch(...) { try { result.reset(new arithmetic_sequence_domain<FieldT>(min_size)); }
-    catch(...) { throw DomainSizeException("get_evaluation_domain: no matching domain"); }}}}}}}}
-    */
-
     return result;
 }
 


### PR DESCRIPTION
This pull request removes the usage of `try ... catch` for control flow in the `get_evaluation_domain` function.

This fixes the problems described by:

 * https://github.com/gstew5/snarkl/issues/11
 * https://github.com/gstew5/snarkl/issues/12
 * https://github.com/ConsenSys/zero-knowledge-proofs/issues/13
 * https://github.com/CodaProtocol/coda/pull/1419 (notable, this made them fork the project & include in their repo instead of a git submodule).

When exception control flow is disabled at the compiler-level, either by choice (to generally speed things up) or by requirement (e.g. the Cheerp WASM compiler doesn't support catching exceptions), then the code either `abort()` or picks the wrong option. This was also triggering misbehaviour with optimised builds on OSX with Clang (where the wrong option is picked, due to buggy catch handling).

This commit also comments-out the comment in the inline-assembly in `basic_radix2_domain_aux.tcc`, which was breaking Emscripten WASM builds due to it lacking support for inline assembly (of any kind).

There is a different patch in https://github.com/CodaProtocol/coda/pull/1419 but it breaks compatibility with the API, this patch remains API compatibility.

I added the `get_root_of_unity_will_throw` function, to determine if getting the root of unity will throw, however I need to avoid duplicating the code at:

 * https://github.com/scipr-lab/libfqfft/compare/master...Ethsnarks:no-exceptional-control-flow?expand=1#diff-7f675b64d35bdeb1d7103625e9b88e69R32
 * https://github.com/scipr-lab/libfqfft/compare/master...Ethsnarks:no-exceptional-control-flow?expand=1#diff-532af60399ad53afa0e3ec23dc6cb717R27

I will make these changes to be included in the pull request.